### PR TITLE
Added ticket update email alerts

### DIFF
--- a/routes/tickets/read-ticket.js
+++ b/routes/tickets/read-ticket.js
@@ -14,6 +14,7 @@ let userAllowedReadKeys = [
   'steps_taken',
   'created_at',
   'updated_at',
+  'title',
   'created_by',
   'ip_assigned_id',
   'sp_assigned_id',

--- a/routes/tickets/read-tickets.js
+++ b/routes/tickets/read-tickets.js
@@ -15,6 +15,7 @@ let userAllowedReadKeys = [
   'steps_taken',
   'created_at',
   'updated_at',
+  'title',
   'ip_assigned_id',
   'sp_assigned_id'
 ];

--- a/routes/tickets/update-ticket.js
+++ b/routes/tickets/update-ticket.js
@@ -18,7 +18,6 @@ module.exports = (Ticket, Email) => {
   return async (req, res) => {
     /* TODO: validate input */
     let data = req.body;
-
     let id = req.params.id;
 
     /* If the updating user is an IP or SP
@@ -32,9 +31,12 @@ module.exports = (Ticket, Email) => {
     }
 
     try {
+      let ticketChanged;
       /* Check if data has changed */
       let [oldData] = await Ticket.findById(id);
-      let ticketChanged;
+      if (oldData.length === 0) {
+        throw new RecordNotFound('ticket does not exist');
+      }
       // Check if any returned data fields are different
       for (field in data) {
         if (data[field] != oldData[field]) {

--- a/routes/tickets/update-ticket.js
+++ b/routes/tickets/update-ticket.js
@@ -34,7 +34,7 @@ module.exports = (Ticket, Email) => {
       let ticketChanged;
       /* Check if data has changed */
       let [oldData] = await Ticket.findById(id);
-      if (oldData.length === 0) {
+      if (typeof oldData === 'undefined') {
         throw new RecordNotFound('ticket does not exist');
       }
       // Check if any returned data fields are different

--- a/routes/tickets/update-ticket.js
+++ b/routes/tickets/update-ticket.js
@@ -46,10 +46,9 @@ module.exports = (Ticket, Email) => {
 
       /* Save data to  db */
       await Ticket.update(id, data, req.user.profile.name);
-
+      let [ticket] = await Ticket.findById(id);
       // if Status updated, email IP and SP
       if (has(data, 'status')) {
-        let [ticket] = await Ticket.findById(id);
         if (ticket.ticket_ip_contact && req.user.role !== 'ip') {
           await Email.notify(
             ticket.ticket_ip_contact,

--- a/test/ticket.test.js
+++ b/test/ticket.test.js
@@ -18,6 +18,7 @@ const prepareTicketData = async context => {
     status: 'ready',
     description: 'bad things',
     date_of_incident: moment(),
+    title: "This ticket",
     ticket_ip_name: 'Alex',
     ticket_ip_contact: 'alex@asdf.org',
     steps_taken: 'tried everything',

--- a/test/ticket.test.js
+++ b/test/ticket.test.js
@@ -18,7 +18,7 @@ const prepareTicketData = async context => {
     status: 'ready',
     description: 'bad things',
     date_of_incident: moment(),
-    title: "This ticket",
+    title: 'This ticket',
     ticket_ip_name: 'Alex',
     ticket_ip_contact: 'alex@asdf.org',
     steps_taken: 'tried everything',

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -38,7 +38,7 @@ module.exports = (client, opts) => {
       },
       newStatus: {
         singular: 'The status of one of your tickets has changed.',
-        plural: 'NUM of your tickets had their status changed.',
+        plural: 'NUM of your tickets had their status changed.'
       },
       newTicket: {
         singular: 'A new ticket was created.',

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -36,6 +36,10 @@ module.exports = (client, opts) => {
         singular: 'One of your tickets was updated.',
         plural: 'NUM of your tickets were updated.',
       },
+      newStatus: {
+        singular: 'The status of one of your tickets has changed.',
+        plural: 'NUM of your tickets had their status changed.',
+      },
       newTicket: {
         singular: 'A new ticket was created.',
         plural: 'NUM new tickets were created.',


### PR DESCRIPTION
A user will only reveive either a tickets status changed update or its ticket changed/updated alert. This prevents a user from receiving multiple updates for a status change.

This pull request will close issue #26 