### PR TITLE
Add SSL as default to DB

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,8 @@
 const environment = process.env.NODE_ENV || 'user';
 const config = require('../knexfile.js')[environment];
+var pg = require('pg');
+
+pg.defaults.ssl = true;
 
 const db = require('knex')(config);
 


### PR DESCRIPTION
Set database defaults through `pg` before connecting to ensure DB/API exchanges use SSL.